### PR TITLE
Make possible batch mailing with 'recipient-variables' parameter

### DIFF
--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -94,7 +94,7 @@ Mailer.send = function (options, callback) {
         mailgunMessage.subject = options.subject || null;
         mailgunMessage.html = options.html || '';
         mailgunMessage.text = options.text || '';
-        mailgunMessage['recipient-variables'] = options['recipient-variables'] || '';
+        // mailgunMessage['recipient-variables'] = options['recipient-variables'] || '';
 
         if (options.replyTo) {
             mailgunMessage['h:Reply-To'] = options.replyTo;

--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -94,7 +94,7 @@ Mailer.send = function (options, callback) {
         mailgunMessage.subject = options.subject || null;
         mailgunMessage.html = options.html || '';
         mailgunMessage.text = options.text || '';
-        mailgunMessage.['recipient-variables'] = options.['recipient-variables'] || '';
+        mailgunMessage['recipient-variables'] = options['recipient-variables'] || '';
 
         if (options.replyTo) {
             mailgunMessage['h:Reply-To'] = options.replyTo;

--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -63,11 +63,9 @@ Mailer.send = function (options, callback) {
 
         if (lo.isString(options.from)) {
             mailgunMessage.from = options.from
-        }
-        else if (lo.isObject(options.from)) {
+        } else if (lo.isObject(options.from)) {
             mailgunMessage.from = options.from.name + '<' + options.from.email + '>';
-        }
-        else {
+        } else {
             var from = [];
             if (options.from_name) {
                 from.push(options.from_name || undefined);
@@ -81,21 +79,19 @@ Mailer.send = function (options, callback) {
 
         if (lo.isString(options.to)) {
             mailgunMessage.to = options.to;
-
-        }
-        else if (lo.isObject(options.to)) {
+        } else if (lo.isArray(options.to)) {
+            mailgunMessage.to = options.to;
+        } else if (lo.isObject(options.to)) {
             mailgunMessage.to = options.to.name + '<' + options.to.email + '>';
-        }
-        else {
+        } else {
             mailgunMessage.to = options.to;
         }
         delete options.to;
 
+
         if (lo.isObject( options['recipient-variables'] )) {
           mailgunMessage['recipient-variables'] = options['recipient-variables'];
         }
-
-        delete options['recipient-variables'];
 
 
         mailgunMessage.subject = options.subject || null;

--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -94,6 +94,8 @@ Mailer.send = function (options, callback) {
         mailgunMessage.subject = options.subject || null;
         mailgunMessage.html = options.html || '';
         mailgunMessage.text = options.text || '';
+        mailgunMessage.['recipient-variables'] = options.['recipient-variables'] || '';
+
         if (options.replyTo) {
             mailgunMessage['h:Reply-To'] = options.replyTo;
         }

--- a/lib/mailgun.js
+++ b/lib/mailgun.js
@@ -91,10 +91,16 @@ Mailer.send = function (options, callback) {
         }
         delete options.to;
 
+        if (lo.isObject( options['recipient-variables'] )) {
+          mailgunMessage['recipient-variables'] = options['recipient-variables'];
+        }
+
+        delete options['recipient-variables'];
+
+
         mailgunMessage.subject = options.subject || null;
         mailgunMessage.html = options.html || '';
         mailgunMessage.text = options.text || '';
-        // mailgunMessage['recipient-variables'] = options['recipient-variables'] || '';
 
         if (options.replyTo) {
             mailgunMessage['h:Reply-To'] = options.replyTo;


### PR DESCRIPTION
Make available the `recipient-variables` parameter in the connector and allow `to` parameter to be an array of emails to work with `recipient-variables`.
ex:
```
loopback.Email.send({
      from: "my@domain.com",
      subject: "welcome %recipient.name%",
      to: ['userA@userDomain.com', 'userB@userDomain.com'],
      html: '<h1> Hi %recipient.name% ! </h1>',
      'recipient-variables': {
        'userA@hisDomain.com' : {
          name : 'user A'
        },
        'userB@hisDomain.com' : {
          name : 'user B'
        }
      }
  })
```

